### PR TITLE
Fixed the Typo(branch spell) in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git checkout -b branch-name
 ```markdown
 git add .
 git commit -m "Your commit Message"
-git push origin brach-name
+git push origin branch-name
 ```
 * Make a pull request.
 * Star the repository if you like.


### PR DESCRIPTION
There was a typo in the "git push origin brach-name" command, I have fixed it.